### PR TITLE
Fix a bug that could cause a deadlock on the REDIS backend.

### DIFF
--- a/Cauldron/redis/client.py
+++ b/Cauldron/redis/client.py
@@ -66,7 +66,7 @@ class Keyword(ClientKeyword, REDISKeywordBase):
             raise NotImplementedError("Keyword '{0}' does not support reads.".format(self.name))
         
         if wait or timeout is not None:
-            self._wait_for_status('ready', timeout)
+            self._wait_for_status('ready', timeout, initial_status='modify')
             self._update_from_redis()
             return self._current_value(binary=binary, both=both)
         else:
@@ -87,7 +87,7 @@ class Keyword(ClientKeyword, REDISKeywordBase):
         self.service.redis.set(redis_key_name(self) + ":status", "modify")
         self.service.redis.publish(redis_key_name(self), value)
         if wait or timeout is not None:
-            self._wait_for_status('ready', timeout)
+            self._wait_for_status('ready', timeout, initial_status="modify")
         
     def wait(self, timeout=None, operator=None, value=None, sequence=None, reset=False, case=False):
         raise CauldronAPINotImplemented("Asynchronous operations are not supported for Cauldron.redis")

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ author_email = arrudy@ucsc.edu
 license = BSD
 edit_on_github = True
 github_project = alexrudy/Cauldron
+url = cauldron.readthedocs.org
 
 [entry_points]
 Cauldron-router-zmq = Cauldron.zmq.router:main


### PR DESCRIPTION
The bug allowed REDIS / the dispatcher to adjust the keyword status before the system tried to wait on the keyword status. This wasn't a problem when the target status was set, but if a non-target status was set (e.g. error), this caused a deadlock.
