### PR TITLE
An extension for Command keywords.

### DIFF
--- a/Cauldron/api.py
+++ b/Cauldron/api.py
@@ -122,7 +122,10 @@ def teardown():
         It is likely that if you call this method with instances of Keyword or Service still active in your application,
         those instances will become unusable.
     """
-    name = registry.client.backend
+    if registry.client.backend is not None:
+        name = registry.client.backend
+    else:
+        name = "unknown"
     registry.teardown()
     try:
         Cauldron = sys.modules[BASENAME]

--- a/Cauldron/ext/commandkeywords/__init__.py
+++ b/Cauldron/ext/commandkeywords/__init__.py
@@ -9,10 +9,12 @@ from Cauldron.exc import NoWriteNecessary
 
 @dispatcher_keyword
 class CommandKeyword(Boolean):
-    """This keyword will recieve boolean writes as 1, and will always be set to 0. 
+    """This keyword will receive boolean writes as 1, and will always be set to 0. 
         
         Actions can then be performed in callbacks, etc., every time this keyword is triggered.
     """
+    
+    KTL_TYPE = 'command'
     
     def __init__(self, *args, **kwargs):
         kwargs['initial'] = '0'
@@ -21,7 +23,7 @@ class CommandKeyword(Boolean):
     def prewrite(self, value):
         """Before writing, trigger no-write-necssary if value is False"""
         if self.translate(value) == '0':
-            raise NoWriteNecessary("No write needed, command not triggerd.")
+            raise NoWriteNecessary("No write needed, command not triggered.")
         return super(CommandKeyword, self).prewrite(value)
     
     def postwrite(self, value):

--- a/Cauldron/ext/commandkeywords/__init__.py
+++ b/Cauldron/ext/commandkeywords/__init__.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""
+An extension for a command-based keyword.
+"""
+from __future__ import absolute_import
+
+from Cauldron.types import Boolean, dispatcher_keyword
+from Cauldron.exc import NoWriteNecessary
+
+@dispatcher_keyword
+class CommandKeyword(Boolean):
+    """This keyword will recieve boolean writes as 1, and will always be set to 0. 
+        
+        Actions can then be performed in callbacks, etc., every time this keyword is triggered.
+    """
+    
+    def __init__(self, *args, **kwargs):
+        kwargs['initial'] = '0'
+        super(CommandKeyword, self).__init__(*args, **kwargs)
+    
+    def prewrite(self, value):
+        """Before writing, trigger no-write-necssary if value is False"""
+        if self.translate(value) == '0':
+            raise NoWriteNecessary("No write needed, command not triggerd.")
+        return super(CommandKeyword, self).prewrite(value)
+    
+    def postwrite(self, value):
+        """Special postwrite that always sets the value to '0'."""
+        self.set('0', force=True)
+    
+    # We don't have to do anything else here.
+        

--- a/Cauldron/ext/commandkeywords/test_commandkeyword.py
+++ b/Cauldron/ext/commandkeywords/test_commandkeyword.py
@@ -52,6 +52,7 @@ def test_callback(dispatcher, client, command_keyword, waittime):
     assert not cb.triggered.is_set()
     cb.triggered.clear()
     
+    dispatcher.log.debug("Client 0 write...")
     client[name].write('0')
     cb.triggered.wait(waittime)
     assert not cb.triggered.is_set()

--- a/Cauldron/ext/commandkeywords/test_commandkeyword.py
+++ b/Cauldron/ext/commandkeywords/test_commandkeyword.py
@@ -12,7 +12,7 @@ def command_keyword(dispatcher):
 def test_write_command_keyword(dispatcher, client, command_keyword):
     """Write to a command keyword."""
     command_keyword.modify('1')
-    assert client[command_keyword.name].read() in ['False', '0']
+    assert client[command_keyword.name].read() == False
     
 def test_callback(dispatcher, client, command_keyword, waittime):
     """Attach a callback to command keywords."""

--- a/Cauldron/ext/commandkeywords/test_commandkeyword.py
+++ b/Cauldron/ext/commandkeywords/test_commandkeyword.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import threading
+
+@pytest.fixture
+def command_keyword(dispatcher):
+    """Make a command-keyword object."""
+    from Cauldron.DFW import Keyword
+    return Keyword.CommandKeyword("COMMAND", dispatcher)
+
+def test_write_command_keyword(dispatcher, client, command_keyword):
+    """Write to a command keyword."""
+    command_keyword.modify('1')
+    assert client[command_keyword.name].read() in ['False', '0']
+    
+def test_callback(dispatcher, client, command_keyword, waittime):
+    """Attach a callback to command keywords."""
+    
+    name = command_keyword.name
+    from Cauldron.exc import DispatcherError
+    
+    print(command_keyword)
+    
+    class CallbackRecieved(Exception): pass
+    
+    def cb(kw):
+        """Dummy Callback"""
+        dispatcher.log.debug("Callback Operating...")
+        cb.triggered.set()
+        raise CallbackRecieved("Notification that {0!r} recieved a callback.".format(kw))
+    
+    cb.triggered = threading.Event()
+    
+    dispatcher[name].callback(cb)
+    with pytest.raises(CallbackRecieved):
+        dispatcher[name].modify('1')
+    
+    cb.triggered.wait(waittime)
+    assert cb.triggered.is_set()
+    cb.triggered.clear()
+    
+    with pytest.raises(DispatcherError):
+        client[name].write('1')
+    
+    cb.triggered.wait(waittime)
+    assert cb.triggered.is_set()
+    cb.triggered.clear()
+    
+    dispatcher[name].modify('0')
+    cb.triggered.wait(waittime)
+    assert not cb.triggered.is_set()
+    cb.triggered.clear()
+    
+    client[name].write('0')
+    cb.triggered.wait(waittime)
+    assert not cb.triggered.is_set()
+    cb.triggered.clear()
+    
+    dispatcher[name].callback(cb, remove=True)
+    dispatcher[name].modify('1')
+    
+    cb.triggered.wait(waittime)
+    assert not cb.triggered.is_set()
+    cb.triggered.clear()
+    
+    

--- a/Cauldron/ext/commandkeywords/test_commandkeyword.py
+++ b/Cauldron/ext/commandkeywords/test_commandkeyword.py
@@ -12,7 +12,7 @@ def command_keyword(dispatcher):
 def test_write_command_keyword(dispatcher, client, command_keyword):
     """Write to a command keyword."""
     command_keyword.modify('1')
-    assert client[command_keyword.name].read() == False
+    assert client[command_keyword.name].read() == '0'
     
 def test_callback(dispatcher, client, command_keyword, waittime):
     """Attach a callback to command keywords."""

--- a/Cauldron/types.py
+++ b/Cauldron/types.py
@@ -143,7 +143,7 @@ class Boolean(Basic):
         """Check value before writing."""
         return super(Boolean, self).prewrite(self.translate(value))
         
-        
+
 @dispatcher_keyword
 class Double(Basic):
     """A numerical value keyword."""

--- a/Cauldron/types.py
+++ b/Cauldron/types.py
@@ -143,7 +143,6 @@ class Boolean(Basic):
         """Check value before writing."""
         return super(Boolean, self).prewrite(self.translate(value))
         
-
 @dispatcher_keyword
 class Double(Basic):
     """A numerical value keyword."""

--- a/extras/Cauldron_redis/client.py
+++ b/extras/Cauldron_redis/client.py
@@ -84,7 +84,6 @@ class Keyword(ClientKeyword, REDISKeywordBase):
         except (TypeError, ValueError):
             pass
         
-        self.service.redis.set(redis_key_name(self) + ":status", "modify")
         self.service.redis.publish(redis_key_name(self), value)
         if wait or timeout is not None:
             self._wait_for_status('ready', timeout, initial_status="modify")

--- a/extras/Cauldron_redis/dispatcher.py
+++ b/extras/Cauldron_redis/dispatcher.py
@@ -90,11 +90,11 @@ class Keyword(DispatcherKeyword):
             except Exception as e:
                 self.service.log.error("Error in the REDIS responder thread for set({0!s}): {1!s}".format(msg["data"], e))
                 self.service.redis.set(redis_key_name(self)+':error', str(e))
-                self.service.redis.set(redis_key_name(self)+':status', 'error')
+                self._redis_set_status('error')
             
     def set(self, value, force=False):
         """During set, lock status."""
-        self.service.redis.set(redis_key_name(self)+':status', 'modify')
+        self._redis_set_status('modify')
         try:
             super(Keyword, self).set(value, force)
         except Exception as e:
@@ -102,6 +102,7 @@ class Keyword(DispatcherKeyword):
             self._redis_set_status('error')
             raise
         else:
-            self.service.redis.set(redis_key_name(self)+':status', 'ready')
+            self.service.log.log(5, "Setting 'ready' from set({0}) which raised no errors.".format(value))
+            self._redis_set_status('ready')
     
 


### PR DESCRIPTION
Command Keywords are boolean keywords which act like buttons. Writing '1' to the keyword triggers the command. When the command is finished, it will be returned to '0'.
